### PR TITLE
FIX: Set the CircularProgressIndicator to the center of the page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -252,8 +252,13 @@ class _MyAppState extends State<MyApp> {
         child: BlocBuilder<BloomeePlayerCubit, BloomeePlayerState>(
           builder: (context, state) {
             if (state is BloomeePlayerInitial) {
-              return const SizedBox(
-                  width: 50, height: 50, child: CircularProgressIndicator());
+              return const Center(
+                child: SizedBox(
+                  width: 50,
+                  height: 50,
+                  child: CircularProgressIndicator(),
+                ),
+              );
             } else {
               return MaterialApp.router(
                 shortcuts: {

--- a/lib/screens/screen/explore_screen.dart
+++ b/lib/screens/screen/explore_screen.dart
@@ -46,6 +46,7 @@ class _ExploreScreenState extends State<ExploreScreen> {
                 .read<BloomeeDBCubit>()
                 .getSettingBool(GlobalStrConsts.autoUpdateNotify) ??
             false) {
+          if (!mounted) return;
           updateDialog(context);
         }
       }
@@ -59,7 +60,10 @@ class _ExploreScreenState extends State<ExploreScreen> {
         if (data.mediaItems.isNotEmpty) {
           return data;
         }
-        lFMData = ctx.read<LastdotfmCubit>().getRecommendedTracks();
+
+        if (ctx.mounted) {
+          lFMData = ctx.read<LastdotfmCubit>().getRecommendedTracks();
+        }
         return (await lFMData);
       } catch (e) {
         log(e.toString(), name: "ExploreScreen");


### PR DESCRIPTION
## Bugfix

## Description
- Fix CircularProgressIndicator being too large when first launching the app

## Evidence

https://github.com/user-attachments/assets/de1fd9ff-6009-40cd-b93d-acab258bf93e


- This is my first PR guys, feel free to discuss if there is anything that needs to be discussed on my code changes, enjoy 😀