### PR TITLE
fix: Skip next/previous buttons not working on Android + memory leaks & crash fixes

### DIFF
--- a/lib/blocs/downloader/cubit/downloader_cubit.dart
+++ b/lib/blocs/downloader/cubit/downloader_cubit.dart
@@ -27,6 +27,7 @@ class DownloaderCubit extends Cubit<DownloaderState> {
   final List<DownloadProgress> _activeDownloads = [];
   final YoutubeExplode _yt = YoutubeExplode();
   StreamSubscription? _librarySubscription;
+  final List<StreamSubscription> _taskSubscriptions = [];
   List<MediaItemModel> _downloadedSongs = [];
 
   DownloaderCubit({
@@ -92,7 +93,7 @@ class DownloaderCubit extends Cubit<DownloaderState> {
 
     _emitUpdatedState();
 
-    task.statusStream.listen((status) {
+    final sub = task.statusStream.listen((status) {
       final index = _activeDownloads
           .indexWhere((item) => item.task.originalUrl == task.originalUrl);
       if (index != -1) {
@@ -108,6 +109,7 @@ class DownloaderCubit extends Cubit<DownloaderState> {
         _emitUpdatedState();
       }
     });
+    _taskSubscriptions.add(sub);
   }
 
   /// --- NEW: Handles saving metadata to the database after completion ---
@@ -173,9 +175,18 @@ class DownloaderCubit extends Cubit<DownloaderState> {
       return;
     }
 
+    // Guard against missing extras/source info
+    final permaUrl = song.extras?['perma_url'];
+    if (song.extras == null || permaUrl == null) {
+      if (showSnackbar)
+        SnackbarService.showMessage(
+            "Cannot download: missing source info for ${song.title}.");
+      return;
+    }
+
     // --- NEW: Perform pre-download checks ---
     if (_activeDownloads
-        .any((item) => item.task.originalUrl == song.extras!['perma_url'])) {
+        .any((item) => item.task.originalUrl == permaUrl)) {
       if (showSnackbar)
         SnackbarService.showMessage("${song.title} is already in the queue.");
       return;
@@ -197,7 +208,7 @@ class DownloaderCubit extends Cubit<DownloaderState> {
 
     final placeholderTask = DownloadTask(
       url: "placeholder", // Will be filled later
-      originalUrl: song.extras!['perma_url'],
+      originalUrl: permaUrl,
       fileName: tempFileName,
       targetPath: path.join(directory.path, tempFileName),
       maxRetries: 3,
@@ -222,7 +233,7 @@ class DownloaderCubit extends Cubit<DownloaderState> {
     try {
       // Update status to fetching metadata
       final index = _activeDownloads.indexWhere(
-          (item) => item.task.originalUrl == song.extras!['perma_url']);
+          (item) => item.task.originalUrl == permaUrl);
       if (index != -1) {
         _activeDownloads[index] = DownloadProgress(
           task: placeholderTask,
@@ -238,8 +249,8 @@ class DownloaderCubit extends Cubit<DownloaderState> {
       String fileName;
       AudioMetadata? metadata;
 
-      if (song.extras!['source'] == 'youtube' ||
-          (song.extras!['perma_url'].toString()).contains('youtube')) {
+      if (song.extras?['source'] == 'youtube' ||
+          permaUrl.toString().contains('youtube')) {
         final video = await _yt.videos.get(song.id.replaceAll("youtube", ""));
         var manifest = await _yt.videos.streams.getManifest(video.id,
             requireWatchPage: true, ytClients: [YoutubeApiClient.androidVr]);
@@ -280,16 +291,10 @@ class DownloaderCubit extends Cubit<DownloaderState> {
           duration: song.duration,
         );
       } else {
-        downloadUrl = song.extras!['url'];
-        final quality =
-            await BloomeeDBService.getSettingStr(GlobalStrConsts.downQuality);
-        if (quality == "High") {
-          downloadUrl =
-              (await getJsQualityURL(downloadUrl, isStreaming: false))!;
-        } else {
-          downloadUrl =
-              (await getJsQualityURL(downloadUrl, isStreaming: false))!;
-        }
+        downloadUrl = song.extras?['url'] ?? '';
+        // getJsQualityURL reads the download quality setting internally
+        downloadUrl =
+            (await getJsQualityURL(downloadUrl, isStreaming: false))!;
         final sanitizedTitle =
             song.title.replaceAll(RegExp(r'[<>:"/\\|?*]'), '_').trim();
         fileName = '$sanitizedTitle by ${song.artist} - ${song.id}.m4a';
@@ -303,11 +308,11 @@ class DownloaderCubit extends Cubit<DownloaderState> {
 
       // Remove the placeholder from active downloads before adding the real task
       _activeDownloads.removeWhere(
-          (item) => item.task.originalUrl == song.extras!['perma_url']);
+          (item) => item.task.originalUrl == permaUrl);
 
       _downloadEngine.addDownload(
         url: downloadUrl,
-        originalUrl: song.extras!['perma_url'],
+        originalUrl: permaUrl,
         directory: directory.path,
         fileName: fileName,
         maxRetries: 3,
@@ -323,7 +328,7 @@ class DownloaderCubit extends Cubit<DownloaderState> {
 
       // Remove the placeholder on error
       _activeDownloads.removeWhere(
-          (item) => item.task.originalUrl == song.extras!['perma_url']);
+          (item) => item.task.originalUrl == permaUrl);
       _emitUpdatedState();
 
       if (showSnackbar)
@@ -334,6 +339,10 @@ class DownloaderCubit extends Cubit<DownloaderState> {
   @override
   Future<void> close() {
     _librarySubscription?.cancel();
+    for (final sub in _taskSubscriptions) {
+      sub.cancel();
+    }
+    _taskSubscriptions.clear();
     _yt.close();
     return super.close();
   }

--- a/lib/blocs/explore/cubit/explore_cubits.dart
+++ b/lib/blocs/explore/cubit/explore_cubits.dart
@@ -108,7 +108,6 @@ class ChartCubit extends Cubit<ChartState> {
 
   @override
   Future<void> close() {
-    fetchChartCubit.close();
     strm?.cancel();
     return super.close();
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -148,7 +148,7 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   // Initialize the player
   // This widget is the root of your application.
-  late StreamSubscription _intentSub;
+  StreamSubscription? _intentSub;
   SharedMedia? sharedMedia;
   @override
   void initState() {
@@ -184,7 +184,7 @@ class _MyAppState extends State<MyApp> {
 
   @override
   void dispose() {
-    _intentSub.cancel();
+    _intentSub?.cancel();
     bloomeePlayerCubit.close();
     if (io.Platform.isWindows || io.Platform.isLinux || io.Platform.isMacOS) {
       DiscordService.clearPresence();

--- a/lib/screens/screen/chart/carousal_widget.dart
+++ b/lib/screens/screen/chart/carousal_widget.dart
@@ -80,6 +80,10 @@ class _CaraouselWidgetState extends State<CaraouselWidget> {
   @override
   void dispose() {
     ss?.cancel();
+    for (final cubit in chartCubitList) {
+      cubit.close();
+    }
+    chartCubitList.clear();
     autoSlideCharts.dispose();
     super.dispose();
   }

--- a/lib/screens/screen/explore_screen.dart
+++ b/lib/screens/screen/explore_screen.dart
@@ -117,15 +117,25 @@ class _ExploreScreenState extends State<ExploreScreen> {
                                   },
                                   child: TabSongListWidget(
                                     list:
-                                        state.mediaPlaylist.mediaItems.map((e) {
+                                        state.mediaPlaylist.mediaItems
+                                            .asMap()
+                                            .entries
+                                            .map((entry) {
+                                      final idx = entry.key;
+                                      final e = entry.value;
                                       return SongCardWidget(
                                         song: e,
                                         onTap: () {
                                           context
                                               .read<BloomeePlayerCubit>()
                                               .bloomeePlayer
-                                              .updateQueue(
-                                            [e],
+                                              .loadPlaylist(
+                                            MediaPlaylist(
+                                              mediaItems: state
+                                                  .mediaPlaylist.mediaItems,
+                                              playlistName: "Recently Played",
+                                            ),
+                                            idx: idx,
                                             doPlay: true,
                                           );
                                         },

--- a/lib/screens/screen/search_screen.dart
+++ b/lib/screens/screen/search_screen.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: public_member_api_docs, sort_constructors_first
 import 'dart:developer';
 import 'package:Bloomee/blocs/mediaPlayer/bloomee_player_cubit.dart';
+import 'package:Bloomee/model/MediaPlaylistModel.dart';
 import 'package:Bloomee/model/source_engines.dart';
 import 'package:Bloomee/screens/widgets/album_card.dart';
 import 'package:Bloomee/screens/widgets/artist_card.dart';
@@ -393,8 +394,12 @@ class _SearchScreenState extends State<SearchScreen> {
                                             context
                                                 .read<BloomeePlayerCubit>()
                                                 .bloomeePlayer
-                                                .updateQueue(
-                                              [state.mediaItems[index]],
+                                                .loadPlaylist(
+                                              MediaPlaylist(
+                                                mediaItems: state.mediaItems,
+                                                playlistName: "Search Results",
+                                              ),
+                                              idx: index,
                                               doPlay: true,
                                             );
                                           },

--- a/lib/screens/widgets/import_playlist.dart
+++ b/lib/screens/widgets/import_playlist.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:Bloomee/screens/widgets/sign_board_widget.dart';
 import 'package:Bloomee/screens/widgets/snackbar.dart';
 import 'package:Bloomee/theme_data/default.dart';
@@ -16,9 +17,11 @@ class _ImporterDialogWidgetState extends State<ImporterDialogWidget> {
   String message = "";
   bool isCompleted = false;
   bool isFailed = false;
+  StreamSubscription<ImporterState>? _subscription;
   @override
   void initState() {
-    widget.strm.listen((event) async {
+    _subscription = widget.strm.listen((event) async {
+      if (!mounted) return;
       setState(() {
         message = event.message;
       });
@@ -39,6 +42,12 @@ class _ImporterDialogWidgetState extends State<ImporterDialogWidget> {
       }
     });
     super.initState();
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    super.dispose();
   }
 
   @override

--- a/lib/services/bloomeePlayer.dart
+++ b/lib/services/bloomeePlayer.dart
@@ -259,6 +259,7 @@ class BloomeeMusicPlayer extends BaseAudioHandler
         MediaAction.seek,
       },
       androidCompactActionIndices: const [0, 1, 2],
+      queueIndex: _queueManager.currentPlayingIdx,
       updatePosition: audioPlayer.position,
       playing: isPlaying,
       bufferedPosition: audioPlayer.bufferedPosition,

--- a/lib/utils/dload.dart
+++ b/lib/utils/dload.dart
@@ -264,7 +264,8 @@ class DownloadEngine {
           await fileSink.close();
           sendPort.send('done');
         },
-        onError: (e) {
+        onError: (e) async {
+          await fileSink.close();
           sendPort.send('Error: ${e.toString()}');
         },
         cancelOnError: true,


### PR DESCRIPTION
### Problem
The skip next/previous buttons (both in Android notification controls and in-app) were completely non-functional. Tapping them did nothing.

### Root Cause
Most playback entry points (search results, recently played) called `updateQueue([singleItem])`, creating a 1-item queue. With only one item, there's nothing to skip to. Also, `PlaybackState` was missing `queueIndex`, which Android's MediaSession needs for proper notification controls.

### Changes

**Skip button fix (3 files):**
- `search_screen.dart` — Load full search results as playlist via `loadPlaylist()` instead of single-item `updateQueue()`
- `explore_screen.dart` — Load full "Recently Played" list as playlist instead of single item
- `bloomeePlayer.dart` — Add `queueIndex` to `PlaybackState` for proper Android MediaSession reporting

**Memory leaks & stability (6 files):**
- `main.dart` — Fix `LateInitializationError` crash on desktop (StreamSubscription nullable)
- `explore_cubits.dart` — Stop incorrectly closing shared `FetchChartCubit` singleton
- `carousal_widget.dart` — Close `ChartCubit` instances in `dispose()`
- `import_playlist.dart` — Store/cancel stream subscription + `mounted` guard
- `downloader_cubit.dart` — Null-safe `extras` access, track task subscriptions, cleanup in `close()`
- `dload.dart` — Close file sink on download segment errors