### PR TITLE
Fix: Deduplicated recently played tracks by ID

### DIFF
--- a/lib/services/db/dao/history_dao.dart
+++ b/lib/services/db/dao/history_dao.dart
@@ -59,11 +59,13 @@ class HistoryDAO {
 
     await Future.wait(entries.map((e) => e.track.load()));
 
+    final seen = <String>{};
     return entries
-        .map((e) => e.track.value)
-        .whereType<TrackDB>()
-        .map(trackDBToTrack)
-        .toList();
+    .map((e) => e.track.value)
+    .whereType<TrackDB>()
+    .where((t) => seen.add(t.mediaId))
+    .map(trackDBToTrack)
+    .toList();
   }
 
   /// Return raw [PlaybackHistoryDB] rows sorted newest-first.


### PR DESCRIPTION
**Issue:** Songs in the recently played section of the home-screen were duplicated if a user replayed the same track multiple times immediately after opening the app.

---
Added a Set-String inside the HistoryDAO.getHistory() to filter duplicate track IDs while iterating over the newest sorted rows. The underlying playback history remains unchanged and the raw log is preserved, while the front facing UI list is decluttered to provide a cleaner viewing experience.  
