### PR TITLE
Add Windows Setup installer build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,10 +76,25 @@ jobs:
 
             - name: Rename file
               run: Rename-Item -Path "build/windows/x64/runner/Release/bloomee.exe" -NewName "Bloomee.exe"
-           
+
             - name: ZIP build
               run: Compress-Archive -Path build/windows/x64/runner/Release/* -Destination  build/windows/x64/bloomee_tunes_windows_x64_v${{ env.VERSION }}+${{github.run_number}}.zip
-            
+
+            - name: Build Windows Installer (Inno Setup)
+              shell: powershell
+              run: |
+                  $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+                  if (-not (Test-Path $iscc)) { throw "ISCC.exe not found at $iscc" }
+                  & $iscc "/DMyAppVersion=$env:VERSION" windows\installer\bloomee.iss
+                  if ($LASTEXITCODE -ne 0) { throw "ISCC.exe failed (exit $LASTEXITCODE)" }
+
+            - name: Rename Installer
+              shell: powershell
+              run: |
+                  $src = "build/windows/x64/installer/bloomee_tunes_windows_x64_v$env:VERSION`_setup.exe"
+                  $dst = "build/windows/x64/installer/bloomee_tunes_windows_x64_v$env:VERSION+${{github.run_number}}_setup.exe"
+                  Rename-Item -Path $src -NewName (Split-Path $dst -Leaf)
+
             - name: Upload Artifacts
               uses: actions/upload-artifact@v4
               with:
@@ -87,6 +102,7 @@ jobs:
                 path: |
                   build/app/outputs/flutter-apk/bloomee_tunes_android_v${{ env.VERSION }}+${{github.run_number}}_universal.apk
                   build/windows/x64/bloomee_tunes_windows_x64_v${{ env.VERSION }}+${{github.run_number}}.zip
+                  build/windows/x64/installer/bloomee_tunes_windows_x64_v${{ env.VERSION }}+${{github.run_number}}_setup.exe
                   build/app/outputs/flutter-apk/bloomee_tunes_android_v${{ env.VERSION }}+${{github.run_number}}_armeabi-v7a.apk
                   build/app/outputs/flutter-apk/bloomee_tunes_android_v${{ env.VERSION }}+${{github.run_number}}_arm64-v8a.apk
                   build/app/outputs/flutter-apk/bloomee_tunes_android_v${{ env.VERSION }}+${{github.run_number}}_x86_64.apk
@@ -98,6 +114,7 @@ jobs:
                 artifacts: |
                   build/app/outputs/flutter-apk/bloomee_tunes_android_v${{ env.VERSION }}+${{github.run_number}}_universal.apk
                   build/windows/x64/bloomee_tunes_windows_x64_v${{ env.VERSION }}+${{github.run_number}}.zip
+                  build/windows/x64/installer/bloomee_tunes_windows_x64_v${{ env.VERSION }}+${{github.run_number}}_setup.exe
                   build/app/outputs/flutter-apk/bloomee_tunes_android_v${{ env.VERSION }}+${{github.run_number}}_armeabi-v7a.apk
                   build/app/outputs/flutter-apk/bloomee_tunes_android_v${{ env.VERSION }}+${{github.run_number}}_arm64-v8a.apk
                   build/app/outputs/flutter-apk/bloomee_tunes_android_v${{ env.VERSION }}+${{github.run_number}}_x86_64.apk

--- a/windows/installer/bloomee.iss
+++ b/windows/installer/bloomee.iss
@@ -1,0 +1,76 @@
+; Inno Setup script for BloomeeTunes (Windows x64, per-user install)
+; Build:  iscc /DMyAppVersion=<ver> windows\installer\bloomee.iss
+; Or run windows\installer\build_installer.ps1 from the repo root.
+
+#ifndef MyAppVersion
+  #define MyAppVersion "0.0.0"
+#endif
+
+#ifndef SourceDir
+  #define SourceDir "..\..\build\windows\x64\runner\Release"
+#endif
+
+#ifndef OutputDir
+  #define OutputDir "..\..\build\windows\x64\installer"
+#endif
+
+#define MyAppName       "Bloomee"
+#define MyAppPublisher  "BloomeeTunes"
+#define MyAppURL        "https://github.com/HemantKArya/BloomeeTunes"
+#define MyAppExeName    "Bloomee.exe"
+
+[Setup]
+; Stable GUID — must never change once published, used to detect prior installs.
+AppId={{5E8A4C3D-1B7F-4A9E-9C2D-8F6A3E1B7C4D}}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppVerName={#MyAppName} {#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}/issues
+AppUpdatesURL={#MyAppURL}/releases
+
+; Per-user install — no UAC, installs into %LocalAppData%\Programs\Bloomee.
+PrivilegesRequired=lowest
+DefaultDirName={autopf}\{#MyAppName}
+DefaultGroupName={#MyAppName}
+DisableProgramGroupPage=yes
+DisableDirPage=no
+AllowNoIcons=yes
+
+; x64 only (Flutter Windows targets x64).
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+
+LicenseFile=..\..\LICENSE
+SetupIconFile=..\runner\resources\app_icon.ico
+UninstallDisplayIcon={app}\{#MyAppExeName}
+UninstallDisplayName={#MyAppName} {#MyAppVersion}
+
+WizardStyle=modern
+Compression=lzma2/ultra64
+SolidCompression=yes
+LZMAUseSeparateProcess=yes
+
+OutputDir={#OutputDir}
+OutputBaseFilename=bloomee_tunes_windows_x64_v{#MyAppVersion}_setup
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[Files]
+; Pull the entire Flutter Windows release bundle: the exe, Flutter engine DLL,
+; Rust FFI DLL, media_kit native libs, audio_service_win, discord_game_sdk,
+; and the data/ folder with assets/fonts/icudtl.
+Source: "{#SourceDir}\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs ignoreversion
+
+[Icons]
+Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
+Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#MyAppName}}"; Flags: nowait postinstall skipifsilent

--- a/windows/installer/build_installer.ps1
+++ b/windows/installer/build_installer.ps1
@@ -1,0 +1,85 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+    Build the Bloomee Windows release and wrap it in an Inno Setup installer.
+
+.DESCRIPTION
+    Runs `flutter build windows --release`, renames bloomee.exe → Bloomee.exe to
+    match the CI artifact name, locates ISCC.exe, and produces
+    build\windows\x64\installer\bloomee_tunes_windows_x64_v<version>_setup.exe.
+
+    Run from the repo root:
+        powershell -ExecutionPolicy Bypass -File .\windows\installer\build_installer.ps1
+
+.PARAMETER SkipBuild
+    Skip the `flutter build windows` step (use an existing Release/ build).
+
+.PARAMETER BuildNumber
+    Optional build number passed through to flutter build. Defaults to 0.
+#>
+[CmdletBinding()]
+param(
+    [switch]$SkipBuild,
+    [int]$BuildNumber = 0
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..\..')
+Set-Location $repoRoot
+
+# --- Extract version from pubspec.yaml --------------------------------------
+$pubspec = Join-Path $repoRoot 'pubspec.yaml'
+$versionLine = Select-String -Path $pubspec -Pattern '^version:\s*(\S+)' | Select-Object -First 1
+if (-not $versionLine) { throw "version not found in $pubspec" }
+$version = $versionLine.Matches[0].Groups[1].Value.Split('+')[0]
+Write-Host "Bloomee version: $version" -ForegroundColor Cyan
+
+# --- Build Flutter Windows release ------------------------------------------
+if (-not $SkipBuild) {
+    Write-Host "Running flutter build windows --release..." -ForegroundColor Cyan
+    & flutter build windows --release --build-number $BuildNumber
+    if ($LASTEXITCODE -ne 0) { throw "flutter build failed (exit $LASTEXITCODE)" }
+}
+
+$releaseDir = Join-Path $repoRoot 'build\windows\x64\runner\Release'
+if (-not (Test-Path $releaseDir)) { throw "Release directory not found: $releaseDir" }
+
+# --- Rename bloomee.exe → Bloomee.exe (matches CI artifact) -----------------
+$lowerExe = Join-Path $releaseDir 'bloomee.exe'
+$properExe = Join-Path $releaseDir 'Bloomee.exe'
+if ((Test-Path $lowerExe) -and -not (Test-Path $properExe)) {
+    Rename-Item -Path $lowerExe -NewName 'Bloomee.exe'
+}
+if (-not (Test-Path $properExe)) { throw "Bloomee.exe missing in $releaseDir" }
+
+# --- Locate ISCC.exe --------------------------------------------------------
+$isccCandidates = @(
+    "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe",
+    "$env:ProgramFiles\Inno Setup 6\ISCC.exe",
+    "$env:LOCALAPPDATA\Programs\Inno Setup 6\ISCC.exe",
+    "${env:ProgramFiles(x86)}\Inno Setup 5\ISCC.exe"
+)
+$iscc = $isccCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+if (-not $iscc) {
+    $cmd = Get-Command ISCC.exe -ErrorAction SilentlyContinue
+    if ($cmd) { $iscc = $cmd.Source }
+}
+if (-not $iscc) {
+    throw "ISCC.exe not found. Install Inno Setup 6 from https://jrsoftware.org/isdl.php"
+}
+Write-Host "Using Inno Setup: $iscc" -ForegroundColor Cyan
+
+# --- Compile installer ------------------------------------------------------
+$iss = Join-Path $PSScriptRoot 'bloomee.iss'
+& $iscc "/DMyAppVersion=$version" $iss
+if ($LASTEXITCODE -ne 0) { throw "ISCC.exe failed (exit $LASTEXITCODE)" }
+
+$outDir = Join-Path $repoRoot 'build\windows\x64\installer'
+$setupExe = Join-Path $outDir "bloomee_tunes_windows_x64_v${version}_setup.exe"
+if (Test-Path $setupExe) {
+    Write-Host ""
+    Write-Host "Installer built: $setupExe" -ForegroundColor Green
+} else {
+    Write-Warning "Build finished but expected output not found at $setupExe"
+}


### PR DESCRIPTION
This PR introduces support for building a Windows installer.

### Changes:

* Added Setup script: `windows/installer/bloomee.iss`
* Added PowerShell build helper: `windows/installer/build_installer.ps1`
* Updated GitHub Actions workflow to:

  * Run ISCC to compile installer
  * Rename release executable
  * Generate versioned `_setup.exe`
  * Upload installer as an additional artifact

### Build Script Features:

* Extracts version from `pubspec.yaml`
* Option to skip Flutter build
* Validates required tools and outputs with proper error reporting

### Notes:

* Changes have been tested locally
* Ready for review and feedback

Let me know if you'd like me to walk through the setup or discuss further improvements.
